### PR TITLE
fix: Add content:write permission to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,7 @@ on:
 permissions:
   id-token: write
   checks: write
+  contents: write
 
 jobs:
   release:


### PR DESCRIPTION
Fix for shareable release action 