### PR TITLE
Reduce min python version to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,10 @@ authors = [
 ]
 description = "Slack plugin for the Solace AI Connector - this provides an input and output component to talk to Slack"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python",  
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
@@ -37,7 +38,7 @@ documentation = "https://github.com/SolaceLabs/solace-ai-connector-slack/blob/ma
 installer = "pip"
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.11", "3.12"]
+python = ["3.10", "3.11", "3.12"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/solace_ai_connector_slack"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ documentation = "https://github.com/SolaceLabs/solace-ai-connector-slack/blob/ma
 installer = "pip"
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.10", "3.11", "3.12"]
+python = ["3.10", "3.12"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/solace_ai_connector_slack"]


### PR DESCRIPTION
## What is the purpose of this change?

This change reduces the minimum Python version required for the Solace AI Connector Slack plugin from 3.11 to 3.10, making it accessible to users who haven't upgraded to Python 3.11 yet.

## How is this accomplished?

- Modified the `requires-python` field in pyproject.toml to specify `>=3.10`
- Added Python 3.10 to the supported classifiers
- Updated the test matrix to include Python 3.10

## Anything reviews should focus on/be aware of?

Reviewers should verify that all dependencies and code features are compatible with Python 3.10, and that tests pass successfully in the Python 3.10 environment.